### PR TITLE
upgrade base64 from 0.13 to 0.21

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,6 @@ rust-version = "1.57"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 hex = "0.4"
-base64 = "0.13"
+base64 = "0.21"
 
 num-bigint = { version = "0.4", optional = true }

--- a/src/test_keys.rs
+++ b/src/test_keys.rs
@@ -1,8 +1,9 @@
 use super::*;
+use base64::Engine;
 
 fn int_from_base64<'de, D: Deserializer<'de>>(deserializer: D) -> Result<LargeInteger, D::Error> {
     let s: &str = Deserialize::deserialize(deserializer)?;
-    let bytes = base64::decode_config(s, base64::URL_SAFE).map_err(D::Error::custom)?;
+    let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(s).map_err(D::Error::custom)?;
     Ok(LargeInteger::new(bytes))
 }
 


### PR DESCRIPTION
ref: https://salsa.debian.org/rust-team/debcargo-conf/-/blob/master/src/wycheproof/debian/patches/upgrade-base64.patch