### PR TITLE
Use one weird trick to reduce the size of your crate by 100+ MB

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,7 @@ macro_rules! define_test_set_names {
             pub fn json_data(&self) -> &'static str {
                 match self {
                     $(
-                        Self::$enum_name => include_str!(concat!("data/", $test_name, "_test.json")),
+                        Self::$enum_name => std::str::from_utf8(include_bytes!(concat!("data/", $test_name, "_test.json"))).expect("Invalid UTF8"),
                     )*
                 }
             }


### PR DESCRIPTION
No, seriously.

For reasons I have not been able to pin down, it seems like include_str is treated differently from include_bytes. This change reduces the sizes of the binaries libwycheproof.rlib and libwycheproof.rmeta from 150M/69M to 88M/7.2M

https://users.rust-lang.org/t/why-do-include-str-and-include-bytes-have-such-different-effect-on-code-size/116676