### PR TITLE
Avoid inlining of the function that returns test data

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,10 +159,11 @@ macro_rules! define_test_set_names {
         }
 
         impl TestName {
+            #[inline(never)]
             pub fn json_data(&self) -> &'static str {
                 match self {
                     $(
-                        Self::$enum_name => std::str::from_utf8(include_bytes!(concat!("data/", $test_name, "_test.json"))).expect("Invalid UTF8"),
+                        Self::$enum_name => include_str!(concat!("data/", $test_name, "_test.json")),
                     )*
                 }
             }


### PR DESCRIPTION
This appears to be the root cause of the binary size blowing up. Using `#[inline(never)]`, there is no difference in crate size between `include_str!` and `include_bytes!`. Probably something about the expect in the `include_bytes!` approach disabled inlining, leading to the observed improvement. Actually just disabling inlining is going to work more reliably, however.